### PR TITLE
Remove shimport debug line

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "sapper dev",
-    "build": "sapper build --legacy && cp ./node_modules/shimport/index.dev.js ./__sapper__/build/client/shimport@1.0.1.js",
+    "build": "sapper build --legacy",
     "build:dev": "npm run build && npm run start",
     "export": "sapper export --legacy",
     "start": "node __sapper__/build",


### PR DESCRIPTION
I think this was just leftover from temporary debugging, so we should remove this. The next version of Sapper will upgrade the Shimport version, so this wouldn't work as intended after that anyway